### PR TITLE
Add two Quip docs related to the project to documentation

### DIFF
--- a/quip-docs/figma-feedback.md
+++ b/quip-docs/figma-feedback.md
@@ -1,0 +1,84 @@
+# Game prototype (Figma Feedback)
+
+### NOTE: Quip is constantly being updated. This document was copied at 6:30pm April 12 2019
+
+Here's comments and issues from David and Drew. Summary of issues:
+
+- Focus first on the building a Community Commons team case - consider whether we can work on building a network commons; also whether we can a community/network connector case
+- Do we have more info content about Theory behind the game - can be later. Priority is something testable.
+- In choosing the scenario, can we add in personas and organisation as commons users
+- Can we add a challenges section to sharpen up choice of tools
+- we need to review/add to categorisation of tools - finding, sharing , collaborating
+- It would be good to have a print tools option to help people scan/discuss tools, then input choices
+
+In addition
+
+- Need to decide whether to use methods or tools as terms. - use methods
+- Should I now split this content up on to separate Quip pages, which might then become a web version?
+
+## User flow instructions:
+
+Numbering relates to Figma screens.
+
+1. Landing page: When ready, click the arrow to continue
+
+Revise to: A game to develop and use a commons platforms for communities and networks
+
+2. About Commons introduction: When ready, click “next” to continue
+
+add commons as a space open to anyone ... building spaces open to anyone. do some definitions
+
+Later there may be two pre-set scenario options - Slipham Commons and Slipham networks. We have keen interest from a consortium of four equalities networks, funded by Big Lottery, that we are working with. Our remit is to develop maps, comms, and a learning space. Very good fit.
+
+Main use cases could be 1) to run a workshop and build the commons - as described here - or 2) how to use the Commons platform as a community connector. An interesting comparison would be 3) as a connector without the platform. But that may be later development!
+
+Link to theory here
+
+3. How to play Instructions page: Currently a placeholder until we have the right copy. When ready, click “next” to continue
+
+We need to look at this - see How to Create a Commons in https://quip.com/qCctAn5dBfDY Do we have a branch to Theory behind the game?
+
+Do we have play as a Commons developer (as now), plus play as a community connector?
+
+- Main sequence
+
+  - Choose and understand your scenario - the situation, and people you wish to support (scenario plus some personas)
+  - Review the challenges you wish to address - how might we .. how can I
+  - Choose the methods you will use
+  - Organise your toolkit and develop a plan
+  - Learn how to use your tools
+
+4. Choose your game play Scenario selection: Click “Play a random scenario” to continue.
+
+For the MVP are we just going to do Slipham Commons, or could we do Slipham Networks as well? That would be good for our job with equalities networks. (as mentioned)
+
+5. Your scenario Scenario summary: When ready, click “next” to continue
+
+Should there be additional screens here (see https://quip.com/qCctAn5dBfDY)
+
+- Personas - examples of the people and organisations that the Commons will serve
+- Challenges. For the Commons development case, the challenges could refer to the personas as users
+
+If we have a community connector use, we could have an option to explore what the commons might be like, with hub/platform cards we have selected. Then the connector adds their own personal-use tools?
+
+6. Select Your Tools page: Click on “More information”
+
+Before going straight into tools, should we have an explanation that tools are categorised Finding, sharing privately, sharing publicly, collaborating. Where we focus on the Commons development use, the tools could be like the ones in https://quip.com/qCctAn5dBfDY. If we have a community connector use there could be more personal methods as well as the ability to use the platform methods.
+
+Could we do a summary of tools before going through one by one?
+
+If the use is by the Commons development team, they are more likely to be working a tablet or computer. Could we have print off, discuss as a team, and input choices?
+
+7. Select Your Tools page: Click on the checkbox for “Use this resource”
+
+I like the way this works ... if we can work out the categorisation - Finding, Sharing, Collaborating (to be agreed)
+
+8. Select Your Tools page: Click on the arrow to see the next available tool
+
+9. Select Your Tools page: Imagining that we have gone through the process of selecting as many tools as we could with the resources that we were allocated, click on the checkbox for “Use this resource” to advance to the final selection.
+
+10. Select Your Tools page: When ready, click “next” to continue
+
+11. Prioritize Your Tools page: Imagining that we have selected a ‘low’ priority and ‘short term’ time frame, click “done” to continue
+
+12. Selection Summary: This is currently our last page! There is still work to be done as far as how information is displayed. We opted not to include the table due to the mobile view, but believe that it might be possible by using icons to represent the cards. We are open to feedback though.

--- a/quip-docs/game-content.md
+++ b/quip-docs/game-content.md
@@ -1,0 +1,311 @@
+# Game and app content
+
+### NOTE: Quip is constantly being updated. This document was copied at 6:30pm April 12 2019
+
+We are now working through app development here - https://quip.com/hwXOAlnRL1rR
+
+Kristina asked for:
+
+1. A definition of commons / intro to network mapping & communication needs
+
+2. Different contextual scenarios
+
+3. The cards you'd like to include
+
+4. Some text on budgeting, prioritising, precursor activities
+
+5. howto resources
+
+I really think that the howto resources are the most important part of this process as it is what inspires real change
+
+This actually has come full circle to the idea that we initially started with, helping people find the resources they need to build their communities
+
+This information needs to be presented in a real practical sense since not everyone will necessesarily be playing with a facilitator
+
+We are developing chunks of content for the game and app that may not follow in sequence, but could also offer break-out explanations. Some of it is marker text at this stage to give an idea of what we can develop.
+
+A lot of it will need to be edited down with links to longer explanations
+
+### Introduction
+
+This app helps you plan and run a workshop to create a Commons - a set of places online and on-the-ground that provide an environment within which connections and collaborations can take place.
+
+Even if you don't want to run a workshop, reading the instructions should still give you ideas about how to clarify the challenges you want to address, create maps of people and places, choose communication and collaboration methods to form a toolkit, and then learn how to use the tools.
+
+Either way you and anyone else interested can join our network of people who want to learn more about maps, apps, storytelling and organising for action.
+
+You can adapt the workshop game and toolkit for use in a locality, an organisation, or for networks that want to work together.
+
+In this app we have used the borough of Slipham as a fictitious example, and populated it with some characters, organisations and projects for you to play with. You can add your own in order to play “for real”.
+
+Link/popups to some definitions/explanations of terms? Some will lead to other sections E.g.
+
+- Workshop
+- Commons
+- Maps
+- Apps
+- Toolkit
+- Networks
+- Online
+
+We could develop an A-Z glossary that links back into sections. Here's one I did a while back - A-Z of effective participation (http://partnerships.org.uk/guide/AZpartic.html).
+
+Provide options in the app at this point?
+
+- _Theory behind the game_. Read about The disconnection problem, the Commons Hub and Platform as a solution, Why workshop games are useful, introduction to network mapping
+- Dive into workshop instructions on _How to create a Commons_
+
+### Theory behind the game
+
+#### The disconnection problem
+
+_Disconnected communities_
+In any community there will be a host of problems, different organisations and groups seeking to address them, gathering places for conversation and events, and a local council struggling its citizens while facing cuts to its funding from government. Some places are of course richer than others - in local wealth, community groups and charities, and service. However all communities will have an undiscovered wealth of assets simply because there may be places that could be better used, tools and skills that could be shared, people who might help each other more given the opportunity. What we need are maps to reveal the places, interests, wants and offers - and ways to connect people and places, and reveal how we can best use our assets.
+
+_Disconnected communication_
+The purpose of this app and workshop game is to help people think through how they can best use the Internet to support ways of communicating and collaborating - in addition to face-to-face conversations and events.
+
+In order to support online communication and collaboration people need to choose and learn tools at different levels:
+
+- Personal tools - e.g. email, text, blog, social media
+- Group tools - as above plus e.g. newsletter, website, document editing, video conferencing, collaboration space
+- Community and network tools - as above plus others like shared calendars
+
+There is a bewildering choice of tools, and people end up in lots of different online places that may not easily connect. This is particularly challenging for anyone attempting to create some common ground for a local community, or a network.
+
+People may be unwilling to join a new system, or a particular commercial platform. Sharing content from one place to another requires facilitation, agreement on what is sharable or not, and connecting tools.
+
+### The Commons hub and platform as a solution
+
+In order to develop a connected commons we need to:
+
+- Understand the nature and of the people, places, organisations of the area, and through that the assets they hold.
+- Develop some shared understanding of the challenges in the area
+- Explore together how to develop some solutions using local assets, plus expertise and resources from elsewhere when necessary
+- Use a range of methods to communicate, collaborate, and organise.
+
+To achieve that, we have evolved a https://quip.com/xUOwAaAlFBXP that includes:
+
+- Mapping of networks and places
+- Management of data, and support for communications systems
+- Network weavers and community connectors
+- Support for projects, events, trails, storytelling
+
+[Image: Connecting Clerkenwell copy 2.png]
+More here about the https://quip.com/xUOwAaAlFBXP
+
+### The workshop game can be used by
+
+1. Hub and platform development team planning which tools will be needed for the Commons
+2. Community connectors planning which tools they will need to use from the platform, or just through personal choice
+3. Project and group leaders planning their communication and collaboration tools
+4. Residents, workers, businesses using the platform/Commons
+
+### Why USE workshop games
+
+The challenge in developing new approaches in this context is that people, groups, organisations will all have their own ways of thinking about things. In order to create the Commons we first need to create a “virtual commons” - a place to develop a shared view of what might be possible. That's the role of the workshop game, and the app.
+
+Playing through a workshop game both helps people choose tools and make plans - and in doing so meet new people and begin to form relationships that they can carry on after the workshop. The game should allow participants to bring their own experience and expertise to the discussions and decisions. The best such games have simple rules that produce complex and thought-provoking outcomes and not the other way around!
+
+### Why mapping is important
+
+The basis for our Commons approach lies in understanding what places, organisations and activities are important to people, and how to increase the ways in which people can find what is useful, share and collaborate.
+
+In order to provide a basis for that we need to develop several sorts of maps: geographic maps that show where things are; story maps that can also display images, audio and video and create tours and trails; and network maps that can include connections as well as locations and media.
+
+Network maps of organisations and individuals can show patterns of influence and potential flows of information. That way they can be useful to anyone developing a network, as well as to those on the network.
+
+This is done through specialist software that can visualise the network and analyse the results while holding various types of information on the resources held by nodes (people and organisations) and the type and strength of connection. The Slipham scenarios contain a network map that shows how various agencies, groups and individuals interact. The map can be interrogated to give information on how central - and therefor potentially influential - a node is, the overall connectedness of the network and clusters according to shared assets / interests or patterns of connection
+
+### What communication tools may be useful
+
+In order to suggest what communication tools may be useful we need to think on at least two dimensions:
+
+- Who will use them, and where: for example by individuals on their phones; in groups working on projects; or more widely in social networks.
+- The main purpose of the tool: for finding information; sharing privately; sharing publicly; for supporting cooperation and collaboration; for managing and facilitating.
+
+We have created a https://quip.com/uj9kA3k1dnJD to show some of the possibilities. The app and workshop game will help you tailor a toolkit of methods for your situation. That might be:
+
+1. Hub and platform development team planning which tools will be needed for the Commons
+2. Community connectors planning which tools they will need to use from the platform, or just through personal choice
+3. Project and group leaders planning their communication and collaboration tools
+4. Residents, workers, businesses using the platform/Commons
+
+### How create a commons
+
+The app will take you through a sequence for the workshop, that you can also use in your own time for planning a Commons or other collaboration and learning space.
+
+You may wish to read about the Theory behind the game, including the challenge of disconnected communities, the idea of a hub and platform to support a Commons, the usefulness of workshops, and the importance of mapping.
+
+If you want to run a workshop - or just explore possibilities - the app and game takes you through this sequence:
+
+1. _Understand the context_ in which you are planning to use mapping and communication tools. We offer several fictitious scenarios - and help you develop your own.
+2. _Populate your scenario._ Choose some fictitious characters and organisations to bring your scenario to life.
+3. _Develop the challenges_ you want to address. We offer some in our fictitious scenarios - or you can create your own.
+4. _Choose your methods_. We offer a set of cards from which you can choose - or add your own.
+5. _Organise your toolkit and develop a plan_. Decide which methods are most important, and when they will be needed.
+6. _Learn how to use your tools_. We offer some howto links, and the opportunity to join our learning community.
+
+At this point in the app we'll get to the stage of choosing/constucting a scenario, populating it with characters and organisations, and then choosing methods. I'm just putting in examples of the content from which people may choose.
+
+### Contextual scenarios
+
+When using the game for general exploration of concepts or for training, it needs a context - a political, social, economic and physical canvas on which method choices and planning can take place. In a real situation the players will know the background, but here we provide a fictitious context that players can use if they wish. Slipham is an urban area with a complex wealth of organisations and individuals whose relationships are shown in an interactive network map that can be interrogated to show interests, assets held and so on. (See url)
+
+[Image: sliphamnet.jpg]
+_Slipham Commons_
+
+The Slipham Social Action centre is launching a Connected Commons programme, aiming to help people explore its heritage, find local opportunities and services, and support new projects for a better Slipham in the future. It will do this by mapping people, projects and groups to find what they can offer, what they need, and how they are connected at present. Community guides and connectors will make acquaintances and introductions, and offer help through meetings and the use of online tools. A hub of staff and volunteers will manage the programme, and run a co-design workshop. Anyone can join in. Here's the invitation:
+
+We are inviting you to help develop the Slipham Commons. This will be a place where people can explore what our town has to offer, connect with people who may have shared interests, and develop further ideas and activities for improvements.
+
+The Commons won't be just one physical space. It will be on-the-ground trails and gathering points, maps of who is doing what, a website and other communication tools, with guides for taking action. We'll have small grants to support projects, and help on fund raising.
+
+The overall aim is to create an environment within which connections and collaborations can take place - the Slipham Connected Commons.
+
+To do that we invite you to a workshop where we will show our first version of Commons maps and ask you to add to them, share some of the challenges we face, and explore what activities and methods could help build the Commons.
+
+### Slipham Networks
+
+Slipham environmental groups have decided that they need to collaborate more effectively with the council and each other in order promote sustainability and combat climate change. They all have memberships, projects and campaigning programme - but at present they don't have ways to connect across their networks and collaborate. To achieve this they have set up a co-ordinating group that is mapping their existing memberships, projects and resources.
+
+The co-ordinating group is running a workshop for all interested parties to agree the main environmental and sustainability challenges, add to their maps, and create a toolkit for communication and collaboration. Teams from different environmental groups will use the kit to work together to explore how to meet the challenges, using resources revealed by the asset mapping, and external connections.
+
+Th groups are running a workshop where their members will add to the maps, agree on some challenges, form teams, and select the tools they need. The co-ordinating group will develop systems for updating the maps and supporting communications.
+
+### Slipham people and organisations - Examples
+
+You can bring your scenario to life by adding some local residents, community connectors and organisations.
+
+[Image: people.jpg][image: connectors.jpg][Image: orgs.jpg]How to use the scenarios, characters and organisations
+
+- Choose the Slipham Commons or Slipham Networks scenario, or create you own on the same lines
+- Populate the scenario with characters and organisations if that is necessary in address you challenges - see below
+
+### Challenges
+
+Develop some HMW challenges that relate to your scenario e.g.
+
+_How Might We (as the Hub development team):_
+
+- Develop a hub and platform to support the Commons
+- Help people find local organisations and services
+- Enable community connectors
+- Develop a project
+
+In each case consider what tools might be needed on the platform; what tools might be used by individuals and groups
+
+_How can I (as a connector) use the Commons:_
+
+- help people find others with whom they might like to collaborate
+- help people up to date on what's happening in the area
+
+_How Can I (as a resident) use the Commons to:_
+
+- find places and people of interest
+- join in a project
+- share my ideas for improvements to the area
+- collaborate with other people
+
+### Methods for connecting and collaborating
+
+These methods are drawn from the https://quip.com/uj9kA3k1dnJD. We can add more from previous games. The aim of the game (at its most ambitious) is to help people choose, plan and use methods for a number of use cases - see above What communication tools may be useful - hub development, community connectors, project leaders, residents.
+
+Is that too ambitious? Should we just focus on two use cases - say hub development and community connector?
+
+Depending on uses cases, methods cards need to be tagged for
+
+- Individual, group or platform use
+- Finding, sharing privately, sharing publicly, collaborating
+- A budget number representing the resources (time, money etc) that activity would require.
+
+_Example methods_
+
+_Directory_
+Lists local organisations and services
+
+_Location map_
+Shows favourite local places and organisations
+
+_Network map_
+Shows who knows who, and how groups and projects connect
+
+_Story map_
+Text, images, audio and video enliven a location map
+
+_Database_
+Spreadsheet to support maps and communications
+
+_Survey tool_
+Allows you to collect data for maps and communications
+
+_Facebook page and group_
+The page can provide the public face, with a group that is open or closed.
+
+_Email newsletter_
+Allows a group to send updates to peoples mailboxes
+
+_Email group_
+Enables many-to-many communications by send emails to and from a central address
+
+_Event organising_
+Tools to schedule events and register attendees
+
+_Events calendar_
+Shared calendar of community or network events
+
+_Blog/news site_
+Update posts and pages. Can add other tools
+
+_Website_
+Web presence for a group or organisation
+
+_Forum_
+Facilitated update and discussion space
+
+_Ideas platform_
+Solicit , discuss and rank idea
+
+_Video conferencing_
+System like Zoom or Skype for webinars and online group events
+
+_Collaborative document system_
+Google docs or Quip
+
+_Aggregators_
+Tools to bring together content from a range of sources
+
+_Private messaging_
+WhatsApp or similar
+
+_Social media_
+Instagram, Twitter
+
+- *Method Card network
+  *The method cards (see xx) are not just randomly distributed. Each card has a set of relationships with other cards which govern or are affected by its operation. These relationships form a network that operates at various scales. The complete set of relationships can be examined at (url here)
+
+The set of cards will show a short description of the method / persona and a cartoon. The purpose of the cartoon is entirely to allow players to easily distinguish between cards. Each card will also indicate other cards that might affect it or be affected by it. Standing behind the cards will be a network map that shows these relationships in a 'cascade' between various levels of operation. (see 'A pattern Language' by Christopher Alexander)
+
+Text on budgeting, prioritising, precursor activities (DM)
+
+### Cards
+
+Each card has a number that represents the resources (time, money etc) that activity would require. The app will generate a 'budget' within which players must select a set of methods that will work best together to address the issues in the scenario. The total of the numbers on the selected cards must not exceed the budget figure. Players must therefore prioritise the cards.
+
+### Timeline
+
+Having selected a set of cards, players must now decide on a plan to implement these methods within the scenario. The timeline screen shows a matrix with timescale ('short', 'medium' and 'long as the column headings and priority ('low', 'medium' and 'high') as the row headings. players must place the cards in the matrix, discussing what is feasible withing the scenario.
+
+(Note that the table below only shows the text and grid. The cells need to be large enough to take several cards)
+
+    TIMESCALE:
+
+SHORT MEDIUM LONG
+PRIORITY: HIGH
+MEDIUM
+LOW
+totals:
+
+Howto resources (DW)
+
+A-Z of a Connected Commons


### PR DESCRIPTION
Quickly converted the "Game Content" and "Prototype Feedback" documents from Quip to basic markdown and added them to the repo.

I think that it's important to keep as much of the documentation as possible in the repo, but these docs were too large to be kept as comments on an issue. I plan to do more, but I am tired and this is tedious work 😅 

Trying to keep Github as a 'single source of truth'!

That said I think it is still worth letting David, Drew, and Barbara use Quip since they seem to do it very well and create a lot of very useful information. I worry that forcing them to do everything on Github will make things a lot slower.