### PR TITLE
Implement small media query to make timeline work on large screens

### DIFF
--- a/client/src/Component/Timeline/index.style.js
+++ b/client/src/Component/Timeline/index.style.js
@@ -15,7 +15,6 @@ export const TermDiv = styled.div`
   background-color: rgba(255, 199, 41, 0.25);
   min-height: 15rem;
   width: 100%;
-  /* margin: 0 -2rem; */
   display: flex;
   flex-direction: row;
 

--- a/client/src/Component/Timeline/index.style.js
+++ b/client/src/Component/Timeline/index.style.js
@@ -14,10 +14,15 @@ export const Arrow = styled.img`
 export const TermDiv = styled.div`
   background-color: rgba(255, 199, 41, 0.25);
   min-height: 15rem;
-  width: 100vw;
-  margin: 0 -2rem;
+  width: 100%;
+  /* margin: 0 -2rem; */
   display: flex;
   flex-direction: row;
+
+  @media (max-width: 426px) {
+    width: 100vw;
+    margin: 0 -2rem;
+  }
 `;
 
 export const ShortTermDiv = styled(TermDiv)`
@@ -47,6 +52,7 @@ export const Subtitle = styled.h3`
   font-weight: 800;
   font-size: 1.5rem;
   text-align: center;
+  z-index: 1;
 `;
 
 export const SubtitleTimeline = styled(Subtitle)`


### PR DESCRIPTION
As the title suggests! Just a little one.

Changes some css at the same breakpoint as the global media query

relates #117 